### PR TITLE
Fix/3 rc jump edge judgment Add/1 rc stick dead zone

### DIFF
--- a/GSRL/Device/inc/dvc_remotecontrol.hpp
+++ b/GSRL/Device/inc/dvc_remotecontrol.hpp
@@ -46,10 +46,11 @@ public:
     } __attribute__((packed));
 
     // DR16遥控器拨杆状态
-    enum SwitchStatus : uint8_t {
+    enum SwitchStatus : int8_t {
         SWITCH_UP = 1,
         SWITCH_DOWN,
-        SWITCH_MIDDLE
+        SWITCH_MIDDLE,
+        SWITCH_ERROR = -1 // 检查m_originalRxDataPointer是否为空
     };
 
     // DR16遥控器拨杆跳变事件
@@ -63,9 +64,10 @@ public:
     };
 
     // DR16遥控器按键状态
-    enum KeyStatus : uint8_t {
+    enum KeyStatus : int8_t {
         KEY_RELEASE = 0,
-        KEY_PRESS
+        KEY_PRESS,
+        KEY_ERROR = -1 // 检查m_originalRxDataPointer是否为空
     };
 
     // DR16遥控器按键跳变事件
@@ -161,6 +163,7 @@ public:
     }
     SwitchStatus getRightSwitchStatus()
     {
+        if (m_originalRxDataPointer == nullptr) return SWITCH_ERROR;
         return m_rightSwitchStatus = (SwitchStatus)m_originalRxDataPointer->Switch_2;
     }
     SwitchEvent getRightSwitchEvent()
@@ -169,6 +172,7 @@ public:
     }
     SwitchStatus getLeftSwitchStatus()
     {
+        if (m_originalRxDataPointer == nullptr) return SWITCH_ERROR;
         return m_leftSwitchStatus = (SwitchStatus)m_originalRxDataPointer->Switch_1;
     }
     SwitchEvent getLeftSwitchEvent()
@@ -192,6 +196,7 @@ public:
     }
     KeyStatus getMouseLeftKeyStatus()
     {
+        if (m_originalRxDataPointer == nullptr) return KEY_ERROR;
         return m_mouseLeftKeyStatus = (KeyStatus)m_originalRxDataPointer->Mouse_Left_Key;
     }
     KeyEvent getMouseLeftKeyEvent()
@@ -200,6 +205,7 @@ public:
     }
     KeyStatus getMouseRightKeyStatus()
     {
+        if (m_originalRxDataPointer == nullptr) return KEY_ERROR;
         return m_mouseRightKeyStatus = (KeyStatus)m_originalRxDataPointer->Mouse_Right_Key;
     }
     KeyEvent getMouseRightKeyEvent()
@@ -208,6 +214,7 @@ public:
     }
     KeyStatus getKeyboardKeyStatus(KeyboardKeyIndex keyIndex)
     {
+        if (m_originalRxDataPointer == nullptr) return KEY_ERROR;
         return m_keyboardKeyStatus[keyIndex] = (KeyStatus)(m_originalRxDataPointer->Keyboard_Key >> keyIndex & 0x01);
     }
     KeyEvent getKeyboardKeyEvent(KeyboardKeyIndex keyIndex)

--- a/GSRL/Device/inc/dvc_remotecontrol.hpp
+++ b/GSRL/Device/inc/dvc_remotecontrol.hpp
@@ -17,6 +17,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "gsrl_common.h"
 #include "drv_uart.h"
+#include <math.h>
 
 /* Exported types ------------------------------------------------------------*/
 
@@ -129,9 +130,10 @@ private:
     bool m_isDr16Connected;
 
     bool m_isDecodeCompleted; // 解码完成标志
+    fp32 m_stickDeadZone;    // 遥控器摇杆死区
 
 public:
-    Dr16RemoteControl();
+    Dr16RemoteControl(fp32 stickDeadZone = 0.0f);
 
     void receiveRxDataFromISR(const uint8_t *data);
     void decodeRxData();
@@ -140,22 +142,22 @@ public:
     fp32 getRightStickX()
     {
         decodeRxData();
-        return m_rightStickX;
+        return applyStickDeadZone(m_rightStickX);
     }
     fp32 getRightStickY()
     {
         decodeRxData();
-        return m_rightStickY;
+        return applyStickDeadZone(m_rightStickY);
     }
     fp32 getLeftStickX()
     {
         decodeRxData();
-        return m_leftStickX;
+        return applyStickDeadZone(m_leftStickX);
     }
     fp32 getLeftStickY()
     {
         decodeRxData();
-        return m_leftStickY;
+        return applyStickDeadZone(m_leftStickY);
     }
     SwitchStatus getRightSwitchStatus()
     {
@@ -256,6 +258,17 @@ private:
                 return KEY_TOGGLE_RELEASE_PRESS;
             default:
                 return KEY_NO_CHANGE;
+        }
+    }
+
+    fp32 applyStickDeadZone(fp32 stickValue)
+    {
+        if (fabs(stickValue) < m_stickDeadZone) {
+            return 0.0f;
+        } else if (stickValue > 0.0f) {
+            return (stickValue - m_stickDeadZone) / (1.0f - m_stickDeadZone);
+        } else {
+            return (stickValue + m_stickDeadZone) / (1.0f - m_stickDeadZone);
         }
     }
 };

--- a/GSRL/Device/src/dvc_remotecontrol.cpp
+++ b/GSRL/Device/src/dvc_remotecontrol.cpp
@@ -92,22 +92,22 @@ void Dr16RemoteControl::decodeRxData()
  */
 void Dr16RemoteControl::updateEvent()
 {
+    if (m_originalRxDataPointer == nullptr) return;
     m_lastRightSwitchStatus   = m_rightSwitchStatus;
     m_rightSwitchStatus       = (SwitchStatus)m_originalRxDataPointer->Switch_2;
-    m_rightSwitchEvent = judgeSwitchStatus(m_rightSwitchStatus, m_lastRightSwitchStatus);
+    m_rightSwitchEvent        = judgeSwitchStatus(m_rightSwitchStatus, m_lastRightSwitchStatus);
     m_lastLeftSwitchStatus    = m_leftSwitchStatus;
     m_leftSwitchStatus        = (SwitchStatus)m_originalRxDataPointer->Switch_1;
-    m_leftSwitchEvent = judgeSwitchStatus(m_leftSwitchStatus, m_lastLeftSwitchStatus);
+    m_leftSwitchEvent         = judgeSwitchStatus(m_leftSwitchStatus, m_lastLeftSwitchStatus);
     m_lastMouseLeftKeyStatus  = m_mouseLeftKeyStatus;
     m_mouseLeftKeyStatus      = (KeyStatus)m_originalRxDataPointer->Mouse_Left_Key;
-    m_mouseLeftKeyEvent = judgeKeyStatus(m_mouseLeftKeyStatus, m_lastMouseLeftKeyStatus);
+    m_mouseLeftKeyEvent       = judgeKeyStatus(m_mouseLeftKeyStatus, m_lastMouseLeftKeyStatus);
     m_lastMouseRightKeyStatus = m_mouseRightKeyStatus;
     m_mouseRightKeyStatus     = (KeyStatus)m_originalRxDataPointer->Mouse_Right_Key;
-    m_mouseRightKeyEvent = judgeKeyStatus(m_mouseRightKeyStatus, m_lastMouseRightKeyStatus);
-    for (uint8_t keyIndex = 0; keyIndex < KEY_TOTAL_NUMBER; keyIndex++)
-    {
+    m_mouseRightKeyEvent      = judgeKeyStatus(m_mouseRightKeyStatus, m_lastMouseRightKeyStatus);
+    for (uint8_t keyIndex = 0; keyIndex < KEY_TOTAL_NUMBER; keyIndex++) {
         m_lastKeyboardKeyStatus[keyIndex] = m_keyboardKeyStatus[keyIndex];
         m_keyboardKeyStatus[keyIndex]     = (KeyStatus)(m_originalRxDataPointer->Keyboard_Key >> keyIndex & 0x01);
-        m_keyboardKeyEvent[keyIndex] = judgeKeyStatus(m_keyboardKeyStatus[keyIndex], m_lastKeyboardKeyStatus[keyIndex]);
+        m_keyboardKeyEvent[keyIndex]      = judgeKeyStatus(m_keyboardKeyStatus[keyIndex], m_lastKeyboardKeyStatus[keyIndex]);
     }
 }

--- a/GSRL/Device/src/dvc_remotecontrol.cpp
+++ b/GSRL/Device/src/dvc_remotecontrol.cpp
@@ -32,14 +32,15 @@
 /**
  * @brief 构造函数，初始化遥控器接收数据地址指针和连接状态
  */
-Dr16RemoteControl::Dr16RemoteControl()
+Dr16RemoteControl::Dr16RemoteControl(fp32 stickDeadZone)
     : m_originalRxDataPointer(nullptr),
       m_rightSwitchEvent(SWITCH_EVENT_NO_UPDATE_ERROR),
       m_leftSwitchEvent(SWITCH_EVENT_NO_UPDATE_ERROR),
       m_mouseLeftKeyEvent(KEY_EVENT_NO_UPDATE_ERROR),
       m_mouseRightKeyEvent(KEY_EVENT_NO_UPDATE_ERROR),
       m_isDr16Connected(false),
-      m_isDecodeCompleted(false)
+      m_isDecodeCompleted(false),
+      m_stickDeadZone(stickDeadZone)
 {
     // 初始化键盘按键状态数组
     for (uint8_t i = 0; i < KEY_TOTAL_NUMBER; i++) {

--- a/GSRL/Device/src/dvc_remotecontrol.cpp
+++ b/GSRL/Device/src/dvc_remotecontrol.cpp
@@ -34,14 +34,25 @@
  */
 Dr16RemoteControl::Dr16RemoteControl()
     : m_originalRxDataPointer(nullptr),
-      m_isDr16Connected(false) {}
+      m_rightSwitchEvent(SWITCH_EVENT_NO_UPDATE_ERROR),
+      m_leftSwitchEvent(SWITCH_EVENT_NO_UPDATE_ERROR),
+      m_mouseLeftKeyEvent(KEY_EVENT_NO_UPDATE_ERROR),
+      m_mouseRightKeyEvent(KEY_EVENT_NO_UPDATE_ERROR),
+      m_isDr16Connected(false),
+      m_isDecodeCompleted(false)
+{
+    // 初始化键盘按键状态数组
+    for (uint8_t i = 0; i < KEY_TOTAL_NUMBER; i++) {
+        m_keyboardKeyEvent[i] = KEY_EVENT_NO_UPDATE_ERROR;
+    }
+}
 
 /**
  * @brief 从中断中获取DR16遥控器接收数据地址，更新相关标志位
  * @param data DR16遥控器接收数据指针
  * @note 本函数不解码遥控器数据
  */
-void Dr16RemoteControl::receiveDr16RxDataFromISR(const uint8_t *data)
+void Dr16RemoteControl::receiveRxDataFromISR(const uint8_t *data)
 {
     m_originalRxDataPointer = (DR16OriginalUARTRxData *)data;
     m_uartRxTimestamp       = HAL_GetTick(); // 更新接收时间戳
@@ -53,7 +64,7 @@ void Dr16RemoteControl::receiveDr16RxDataFromISR(const uint8_t *data)
  * @brief 接收DR16遥控器数据后解码数据, 判断遥控器连接状态
  * @note 本函数在使用get函数获取遥控器数据时自动调用
  */
-void Dr16RemoteControl::decodeDr16RxData()
+void Dr16RemoteControl::decodeRxData()
 {
     // 判断遥控器连接状态，若使用的数据过时超过100ms则认为遥控器断开
     if (HAL_GetTick() - m_uartRxTimestamp > 100 || m_originalRxDataPointer == nullptr) {
@@ -71,4 +82,31 @@ void Dr16RemoteControl::decodeDr16RxData()
     m_mouseYSpeed       = (fp32)(m_originalRxDataPointer->Mouse_Y / 32768.0f);
     m_mouseWheelSpeed   = (fp32)(m_originalRxDataPointer->Mouse_Z / 32768.0f);
     m_isDecodeCompleted = true; // 更新解码完成标志，避免重复解码
+}
+
+/**
+ * @brief 更新所有按键和拨杆的跳变事件并缓存
+ * @note 使用get方法获取按键状态前请先调用本函数
+ * @note 建议在每个控制循环的开头调用一次，且一个控制循环内只调用一次，以保证控制循环中获取的事件状态一致
+ */
+void Dr16RemoteControl::updateEvent()
+{
+    m_lastRightSwitchStatus   = m_rightSwitchStatus;
+    m_rightSwitchStatus       = (SwitchStatus)m_originalRxDataPointer->Switch_2;
+    m_rightSwitchEvent = judgeSwitchStatus(m_rightSwitchStatus, m_lastRightSwitchStatus);
+    m_lastLeftSwitchStatus    = m_leftSwitchStatus;
+    m_leftSwitchStatus        = (SwitchStatus)m_originalRxDataPointer->Switch_1;
+    m_leftSwitchEvent = judgeSwitchStatus(m_leftSwitchStatus, m_lastLeftSwitchStatus);
+    m_lastMouseLeftKeyStatus  = m_mouseLeftKeyStatus;
+    m_mouseLeftKeyStatus      = (KeyStatus)m_originalRxDataPointer->Mouse_Left_Key;
+    m_mouseLeftKeyEvent = judgeKeyStatus(m_mouseLeftKeyStatus, m_lastMouseLeftKeyStatus);
+    m_lastMouseRightKeyStatus = m_mouseRightKeyStatus;
+    m_mouseRightKeyStatus     = (KeyStatus)m_originalRxDataPointer->Mouse_Right_Key;
+    m_mouseRightKeyEvent = judgeKeyStatus(m_mouseRightKeyStatus, m_lastMouseRightKeyStatus);
+    for (uint8_t keyIndex = 0; keyIndex < KEY_TOTAL_NUMBER; keyIndex++)
+    {
+        m_lastKeyboardKeyStatus[keyIndex] = m_keyboardKeyStatus[keyIndex];
+        m_keyboardKeyStatus[keyIndex]     = (KeyStatus)(m_originalRxDataPointer->Keyboard_Key >> keyIndex & 0x01);
+        m_keyboardKeyEvent[keyIndex] = judgeKeyStatus(m_keyboardKeyStatus[keyIndex], m_lastKeyboardKeyStatus[keyIndex]);
+    }
 }

--- a/Task/src/tsk_test.cpp
+++ b/Task/src/tsk_test.cpp
@@ -92,7 +92,7 @@ extern "C" void test_task(void *argument)
  */
 extern "C" void dr16ITCallback(uint8_t *Buffer, uint16_t Length)
 {
-    dr16.receiveDr16RxDataFromISR(Buffer);
+    dr16.receiveRxDataFromISR(Buffer);
 }
 
 


### PR DESCRIPTION
This pull request refactors and extends the `Dr16RemoteControl` class to improve event detection and handling for remote control switches and keys, as well as to add support for stick dead zones. The changes introduce new enums for event types, update internal state management, provide clearer and more robust getter methods, and add a method for updating event states. Several naming improvements and code cleanups are also included.

Key improvements and changes:

**Event Handling and State Management:**
* Added new enums `SwitchEvent` and `KeyEvent` to represent switch/key transition events, including error states for improper usage. (`[GSRL/Device/inc/dvc_remotecontrol.hppL51-R76](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L51-R76)`)
* Added new member variables to store both the current status and the event (transition) for switches and keys, and updated all relevant getter and internal logic accordingly. (`[GSRL/Device/inc/dvc_remotecontrol.hppL95-R232](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L95-R232)`)
* Introduced the `updateEvent()` method, which updates all switch and key events and caches their states. This method should be called once per control loop to ensure consistent event detection. (`[GSRL/Device/src/dvc_remotecontrol.cppR87-R113](diffhunk://#diff-2e9a8fb8055c50f3b121d105878ed54b5a4b9bde2345b8057270af8a21ee38d4R87-R113)`)

**Stick Dead Zone Support:**
* Added a `m_stickDeadZone` member and an `applyStickDeadZone()` method to filter out small stick movements, improving control stability. The dead zone can be set via the constructor. (`[[1]](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L95-R232)`, `[[2]](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L211-R271)`, `[[3]](diffhunk://#diff-2e9a8fb8055c50f3b121d105878ed54b5a4b9bde2345b8057270af8a21ee38d4L35-R56)`)

**API and Naming Improvements:**
* Renamed methods and member variables for clarity (e.g., `receiveDr16RxDataFromISR` → `receiveRxDataFromISR`, `decodeDr16RxData` → `decodeRxData`, and status/event variable names). (`[[1]](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L95-R232)`, `[[2]](diffhunk://#diff-2e9a8fb8055c50f3b121d105878ed54b5a4b9bde2345b8057270af8a21ee38d4L35-R56)`, `[[3]](diffhunk://#diff-2e9a8fb8055c50f3b121d105878ed54b5a4b9bde2345b8057270af8a21ee38d4L56-R68)`, `[[4]](diffhunk://#diff-ac26fd393bfe819c09c2b566528d63fb7a4728dc1513887b795c158f8418d748L95-R95)`)
* Getter methods for switches and keys now provide access to both status and event types, and use the new dead zone logic for stick axes. (`[GSRL/Device/inc/dvc_remotecontrol.hppL95-R232](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L95-R232)`)

**Enum and Array Enhancements:**
* Added `KEY_TOTAL_NUMBER` to the keyboard key index enum to simplify array management and initialization. (`[[1]](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L83-R97)`, `[[2]](diffhunk://#diff-2e9a8fb8055c50f3b121d105878ed54b5a4b9bde2345b8057270af8a21ee38d4L35-R56)`)

These changes make the remote control interface more robust, easier to use, and better suited for event-driven input handling in control loops.

**References:**  
[[1]](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L51-R76) [[2]](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L95-R232) [[3]](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L83-R97) [[4]](diffhunk://#diff-2ffebfdf03410b258a1c3be3a877f3c3378c8c19df67d2a2c2c771a875166d46L211-R271) [[5]](diffhunk://#diff-2e9a8fb8055c50f3b121d105878ed54b5a4b9bde2345b8057270af8a21ee38d4L35-R56) [[6]](diffhunk://#diff-2e9a8fb8055c50f3b121d105878ed54b5a4b9bde2345b8057270af8a21ee38d4R87-R113) [[7]](diffhunk://#diff-2e9a8fb8055c50f3b121d105878ed54b5a4b9bde2345b8057270af8a21ee38d4L56-R68) [[8]](diffhunk://#diff-ac26fd393bfe819c09c2b566528d63fb7a4728dc1513887b795c158f8418d748L95-R95)